### PR TITLE
Close #2: Replace deprecated X-XSS-Protection check with modern headers

### DIFF
--- a/scanners/web_scanner.py
+++ b/scanners/web_scanner.py
@@ -15,11 +15,6 @@ from packaging import version
 # Define vulnerability checks grouped by category.
 VULN_CHECKS = {
     "Security Header Misconfigurations": {
-        "Missing X-XSS-Protection": {  # TODO: deprecated; keep for now (see issue #2)
-            "header": "X-XSS-Protection",
-            "severity": 7,
-            "remediation": "Implement X-XSS-Protection header to prevent XSS attacks."
-        },
         "Missing HSTS": {
             "header": "Strict-Transport-Security",
             "severity": 7,
@@ -35,6 +30,21 @@ VULN_CHECKS = {
             "severity": 8,
             "remediation": "Use Content Security Policy to mitigate cross-site scripting attacks."
         },
+        "Missing X-Content-Type-Options": {
+            "header": "X-Content-Type-Options",
+            "severity": 6,
+            "remediation": "Set X-Content-Type-Options: nosniff to reduce MIME-sniffing attacks."
+        },
+        "Missing Referrer-Policy": {
+            "header": "Referrer-Policy",
+            "severity": 5,
+            "remediation": "Set a Referrer-Policy to control referrer leakage (e.g., strict-origin-when-cross-origin)."
+        },
+        "Missing Permissions-Policy": {
+            "header": "Permissions-Policy",
+            "severity": 5,
+            "remediation": "Set a Permissions-Policy to explicitly allow/deny powerful browser features."
+        }
     }
 }
 

--- a/tests/test_check_header.py
+++ b/tests/test_check_header.py
@@ -35,11 +35,11 @@ class DummySession:
         return DummyResponse(self.headers)
 
 @pytest.mark.asyncio
-async def test_check_header_x_xss_protection_present():
-    """Verify check_header returns the X-XSS-Protection value when present."""
-    dummy_session = DummySession(headers={"X-XSS-Protection": "1; mode=block"})
-    result = await check_header(dummy_session, "http://example.com", "X-XSS-Protection")
-    assert result == "1; mode=block"
+async def test_check_header_x_content_type_options_present():
+    """Verify check_header returns the X-Content-Type-Options value when present."""
+    dummy_session = DummySession(headers={"X-Content-Type-Options": "nosniff"})
+    result = await check_header(dummy_session, "http://example.com", "X-Content-Type-Options")
+    assert result == "nosniff"
 
 @pytest.mark.asyncio
 async def test_check_header_hsts_valid():
@@ -60,7 +60,7 @@ async def test_check_header_x_frame_options_present():
 @pytest.mark.asyncio
 async def test_check_header_csp_present():
     """Verify check_header returns the CSP value when present."""
-    dummy_session = DummySession(headers={"CSP": "default-src 'self'"})
+    dummy_session = DummySession(headers={"Content-Security-Policy": "default-src 'self'"})
     result = await check_header(dummy_session, "http://example.com", "Content-Security-Policy")
     assert result == "default-src 'self'"
 
@@ -68,7 +68,7 @@ async def test_check_header_csp_present():
 async def test_check_header_exception():
     """Verify check_header returns None when an exception is raised."""
     dummy_session = DummySession(headers={}, raise_exception=True)
-    result = await check_header(dummy_session, "http://example.com", "X-XSS-Protection")
+    result = await check_header(dummy_session, "http://example.com", "X-Content-Type-Options")
     assert result is None
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2.

### Rationale
X-XSS-Protection is deprecated and ignored by modern browsers. MASAT should focus on headers that still provide value today.

### Changes
- Removed the X-XSS-Protection check.
- Added checks for:
  - X-Content-Type-Options
  - Referrer-Policy
  - Permissions-Policy
- Updated unit tests accordingly.

### Dependency note
This PR is based on the header-mapping fix from PR #3 (HSTS/CSP header detection). It will merge cleanly after PR #3.