### PR TITLE
Test: Enable pytest-asyncio so async unit tests actually run

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    asyncio: mark a test as async/await using pytest-asyncio
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.11.14
 packaging==24.2
 pytest==8.3.5
+pytest-asyncio==0.25.3


### PR DESCRIPTION
### Problem
The repo includes async tests marked with @pytest.mark.asyncio, but pytest was skipping all async tests because no async plugin was installed.

### Changes
- Add pytest-asyncio to requirements.txt
- Add pytest.ini to register the asyncio marker and enable asyncio_mode=auto

### Result
- Async tests now execute (instead of being silently skipped).