### PR TITLE
Feat: plugin-style scanner registry + --list-scans/--scans

### DIFF
--- a/scanners/nmap_scanner.py
+++ b/scanners/nmap_scanner.py
@@ -6,6 +6,9 @@ License: Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 LinkedIn: https://www.linkedin.com/in/danielewood
 GitHub: https://github.com/automatesecurity
 """
+
+SCAN_ID = "nmap"
+DESCRIPTION = "Port and service scan via nmap."
 import asyncio
 import logging
 

--- a/scanners/registry.py
+++ b/scanners/registry.py
@@ -1,0 +1,51 @@
+"""Scanner registry and discovery.
+
+This enables a lightweight plugin architecture: any module in `scanners/` that
+exposes a coroutine named `scan(target, verbose=False)` can be discovered.
+
+Optional module attributes:
+- SCAN_ID: stable identifier (default: module name)
+- DESCRIPTION: human-readable description
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Callable, Awaitable
+
+
+@dataclass(frozen=True)
+class ScannerSpec:
+    scan_id: str
+    description: str
+    module: ModuleType
+
+    @property
+    def scan(self) -> Callable[..., Awaitable[dict]]:
+        return getattr(self.module, "scan")
+
+
+def discover_scanners() -> dict[str, ScannerSpec]:
+    """Discover scanner modules under the `scanners` package."""
+    import scanners  # local package
+
+    specs: dict[str, ScannerSpec] = {}
+    for modinfo in pkgutil.iter_modules(scanners.__path__, scanners.__name__ + "."):
+        if modinfo.name.endswith(".registry"):
+            continue
+
+        module = importlib.import_module(modinfo.name)
+
+        scan_fn = getattr(module, "scan", None)
+        if scan_fn is None:
+            continue
+
+        scan_id = getattr(module, "SCAN_ID", modinfo.name.split(".")[-1])
+        description = getattr(module, "DESCRIPTION", "")
+
+        specs[scan_id] = ScannerSpec(scan_id=scan_id, description=description, module=module)
+
+    return dict(sorted(specs.items(), key=lambda kv: kv[0]))

--- a/scanners/tls_scanner.py
+++ b/scanners/tls_scanner.py
@@ -6,6 +6,9 @@ License: Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 LinkedIn: https://www.linkedin.com/in/danielewood
 GitHub: https://github.com/automatesecurity
 """
+
+SCAN_ID = "tls"
+DESCRIPTION = "TLS/SSL scan (protocols, ciphers, cert validity)."
 import asyncio
 import ssl
 import logging

--- a/scanners/web_crawler.py
+++ b/scanners/web_crawler.py
@@ -6,6 +6,9 @@ License: Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 LinkedIn: https://www.linkedin.com/in/danielewood
 GitHub: https://github.com/automatesecurity
 """
+
+SCAN_ID = "crawler"
+DESCRIPTION = "Web crawler (discover endpoints and common sensitive paths)."
 import asyncio
 import logging
 import aiohttp

--- a/scanners/web_scanner.py
+++ b/scanners/web_scanner.py
@@ -12,6 +12,9 @@ import aiohttp
 import re
 from packaging import version
 
+SCAN_ID = "web"
+DESCRIPTION = "Web vulnerability scan (headers, risky methods, library fingerprints)."
+
 # Define vulnerability checks grouped by category.
 VULN_CHECKS = {
     "Security Header Misconfigurations": {


### PR DESCRIPTION
### Why
This makes MASAT extensible without hardcoding every scanner in scanner.py.

### Changes
- Add scanners/registry.py which discovers scanner modules under scanners/
- Each scanner module now declares:
  - SCAN_ID (stable id)
  - DESCRIPTION (for --list-scans)
- scanner.py can now:
  - --list-scans (no --target required)
  - --scans web,tls,nmap (comma separated)
  - --scan-all uses the registry for available scans
- Existing flags (--web/--tls/--nmap/--crawler) still work for backwards compatibility

### Notes
This is a foundation for future improvements like subdomain enumeration and additional protocol scanners as drop-in modules.