### PR TITLE
Feat: Passive subdomain enumeration (crt.sh)

### DIFF
--- a/scanners/subdomain_scanner.py
+++ b/scanners/subdomain_scanner.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Passive subdomain enumeration.
+
+Uses Certificate Transparency (crt.sh) as a low-friction source for discovered
+subdomains. This is intended as recon/OSINT and is informational.
+
+Note: crt.sh is a public service and may rate-limit. Keep queries small and
+handle failures gracefully.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+from urllib.parse import urlparse
+
+SCAN_ID = "subdomains"
+DESCRIPTION = "Passive subdomain enumeration via Certificate Transparency (crt.sh)."
+
+
+def extract_domain(target: str) -> str:
+    """Extract a domain from a URL/hostname/IP target string."""
+    parsed = urlparse(target)
+    host = parsed.hostname if parsed.hostname else target
+    # crude normalization: strip port if user passed host:port without scheme
+    if host and ":" in host and host.count(":") == 1:
+        host = host.split(":", 1)[0]
+    return host
+
+
+def normalize_crtsh_names(name_value: str) -> list[str]:
+    """Split a crt.sh name_value into normalized DNS names."""
+    names: list[str] = []
+    for raw in (name_value or "").split("\n"):
+        n = raw.strip().lower()
+        if not n:
+            continue
+        # crt.sh often returns wildcards.
+        if n.startswith("*."):
+            n = n[2:]
+        names.append(n)
+    return names
+
+
+async def scan(target: str, verbose: bool = False) -> dict:
+    domain = extract_domain(target)
+    if not domain:
+        return {"Subdomain Enumeration": {"No domain provided": {"severity": 0, "remediation": "None"}}}
+
+    url = f"https://crt.sh/?q=%25.{domain}&output=json"
+
+    subdomains: set[str] = set()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=20) as resp:
+                if resp.status != 200:
+                    return {
+                        "Subdomain Enumeration": {
+                            "crt.sh query failed": {
+                                "severity": 0,
+                                "remediation": "None",
+                                "details": f"HTTP {resp.status} from crt.sh",
+                            }
+                        }
+                    }
+                data = await resp.json(content_type=None)
+
+        for row in data:
+            for n in normalize_crtsh_names(row.get("name_value", "")):
+                # keep results within the queried domain.
+                if n == domain or n.endswith("." + domain):
+                    subdomains.add(n)
+
+    except Exception as e:
+        return {
+            "Subdomain Enumeration": {
+                "crt.sh query exception": {
+                    "severity": 0,
+                    "remediation": "None",
+                    "details": str(e),
+                }
+            }
+        }
+
+    results = sorted(subdomains)
+    if verbose:
+        print(f"[SUBDOMAIN SCANNER] Found {len(results)} subdomains for {domain}")
+
+    return {
+        "Subdomain Enumeration": {
+            "Subdomains discovered": {
+                "severity": 0,
+                "remediation": "Review discovered subdomains for unexpected exposures and ensure they are covered by monitoring.",
+                "details": ", ".join(results) if results else "None",
+            }
+        }
+    }

--- a/tests/test_subdomain_scanner.py
+++ b/tests/test_subdomain_scanner.py
@@ -1,0 +1,16 @@
+import pytest
+
+from scanners.subdomain_scanner import extract_domain, normalize_crtsh_names
+
+
+def test_extract_domain_from_url():
+    assert extract_domain("https://example.com/path") == "example.com"
+
+
+def test_extract_domain_from_host_port():
+    assert extract_domain("example.com:8443") == "example.com"
+
+
+def test_normalize_crtsh_names_splits_and_strips_wildcards():
+    names = normalize_crtsh_names("*.a.example.com\nb.EXAMPLE.com\n\n")
+    assert names == ["a.example.com", "b.example.com"]


### PR DESCRIPTION
### What
Adds a new scanner module: subdomains.

### Why
Implements the README Future Improvements item for enhanced recon (passive OSINT) and expands MASAT beyond point-in-time URL checks.

### How
- Queries Certificate Transparency via crt.sh (https://crt.sh/?q=%.<domain>&output=json)
- Normalizes wildcard names and filters results to the queried domain
- Returns an informational findings section with discovered subdomains

### Usage
python3 scanner.py --target https://example.com --scans subdomains --verbose

### Notes
crt.sh is a public service and may rate-limit; failures are handled gracefully.