### PR TITLE
Fix: restore output flags + Slack notification loop

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -136,6 +136,18 @@ def main():
     )
     parser.add_argument("--verbose", action="store_true", help="Print status to stdout")
 
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help="Optional path to write output (defaults to stdout).",
+    )
+
     # Integrations
     parser.add_argument(
         "--slack-webhook",
@@ -216,7 +228,7 @@ def main():
     # Optional Slack notification
     if args.slack_webhook:
         formatted_message = format_findings_for_slack(results)
-        loop.run_until_complete(send_slack_notification(args.slack_webhook, formatted_message, verbose=args.verbose))
+        asyncio.run(send_slack_notification(args.slack_webhook, formatted_message, verbose=args.verbose))
     else:
         logging.info("Slack webhook not configured; skipping Slack notification.")
 


### PR DESCRIPTION
### Problem
scanner.py referenced args.output / args.output_file and a loop variable that were not defined, causing runtime errors.

### Fix
- Re-add --output and --output-file CLI flags
- Use asyncio.run(...) for Slack notification to avoid undefined event loop usage

### Verification
- pytest
- scanner.py --web --output json}