### PR TITLE
Feat: smart workflow planning (auto-select scans by target type)

### DIFF
--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,20 @@
+from utils.targets import parse_target
+from utils.workflows import plan_scans
+
+
+def test_plan_for_url_includes_web():
+    info = parse_target("https://example.com")
+    plan = plan_scans(info)
+    assert "web" in plan.scans
+
+
+def test_plan_for_host_includes_nmap():
+    info = parse_target("example.com")
+    plan = plan_scans(info)
+    assert "nmap" in plan.scans
+
+
+def test_plan_for_cidr_includes_nmap_only():
+    info = parse_target("10.0.0.0/24")
+    plan = plan_scans(info)
+    assert "nmap" in plan.scans

--- a/utils/targets.py
+++ b/utils/targets.py
@@ -1,0 +1,51 @@
+"""Target parsing and classification."""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class TargetInfo:
+    raw: str
+    kind: str  # url|host|ip|cidr
+    host: str | None
+    scheme: str | None
+    port: int | None
+
+
+def parse_target(target: str) -> TargetInfo:
+    t = (target or "").strip()
+    parsed = urlparse(t)
+
+    if parsed.scheme and parsed.hostname:
+        host = parsed.hostname
+        return TargetInfo(raw=t, kind="url", host=host, scheme=parsed.scheme, port=parsed.port)
+
+    # CIDR?
+    try:
+        ipaddress.ip_network(t, strict=False)
+        if "/" in t:
+            return TargetInfo(raw=t, kind="cidr", host=None, scheme=None, port=None)
+    except Exception:
+        pass
+
+    # IP?
+    try:
+        ipaddress.ip_address(t)
+        return TargetInfo(raw=t, kind="ip", host=t, scheme=None, port=None)
+    except Exception:
+        pass
+
+    # host[:port]
+    host = t
+    port = None
+    if ":" in t and t.count(":") == 1:
+        h, p = t.split(":", 1)
+        if h and p.isdigit():
+            host = h
+            port = int(p)
+
+    return TargetInfo(raw=t, kind="host", host=host, scheme=None, port=port)

--- a/utils/workflows.py
+++ b/utils/workflows.py
@@ -1,0 +1,58 @@
+"""Smart scan planning for MASAT.
+
+This is the orchestration layer to help MASAT decide which scans to run for a
+given target.
+
+Design:
+- Keep it lightweight by default.
+- Prefer deterministic, explainable plans.
+- Make potentially-expensive expansions (subdomains) opt-in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scanners.registry import discover_scanners
+from utils.targets import TargetInfo
+
+
+@dataclass(frozen=True)
+class ScanPlan:
+    target: str
+    scans: list[str]
+    rationale: list[str]
+
+
+def plan_scans(info: TargetInfo, include_nuclei: bool = True) -> ScanPlan:
+    registry = discover_scanners()
+    scans: list[str] = []
+    rationale: list[str] = []
+
+    def add(scan_id: str, why: str):
+        if scan_id in registry and scan_id not in scans:
+            scans.append(scan_id)
+            rationale.append(f"{scan_id}: {why}")
+
+    if info.kind == "url":
+        add("web", "URL target → run web header/method/library checks")
+        if info.scheme == "https":
+            add("tls", "HTTPS URL → run TLS scan")
+        add("banners", "Grab lightweight banners for common ports")
+        if include_nuclei:
+            add("nuclei", "Run nuclei CVE/misconfig templates (if installed)")
+
+    elif info.kind in ("host", "ip"):
+        add("banners", "Host/IP target → quick banner fingerprinting")
+        add("nmap", "Host/IP target → ports/services inventory")
+        add("tls", "If 443 is open, TLS scan will add signal")
+        if include_nuclei:
+            add("nuclei", "Run nuclei against host (best-effort)")
+
+    elif info.kind == "cidr":
+        add("nmap", "CIDR target → port/service discovery across range (can be expensive)")
+
+    else:
+        add("web", "Default to web scan")
+
+    return ScanPlan(target=info.raw, scans=scans, rationale=rationale)


### PR DESCRIPTION
### What
Adds a lightweight orchestration layer so MASAT can pick a sensible scan set based on the input target.

### New flags
- --smart: auto-select scans
- --plan: print the selected plan + rationale and exit

### Why
This is the first step toward the portal goal: a user enters a domain/IP/CIDR and MASAT chooses workflows automatically.

### Notes
- Keeps explicit flags and --scans working.
- Planning is explainable (includes rationale strings).