### PR TITLE
Feat: normalized findings schema + SQLite run history

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+
+from utils.history import default_db_path, list_runs, store_run
+
+
+def test_default_db_path_endswith_db():
+    assert default_db_path().endswith("masat.db")
+
+
+def test_store_and_list_runs_roundtrip():
+    with tempfile.TemporaryDirectory() as td:
+        db = os.path.join(td, "t.db")
+        run_id = store_run(db, "example.com", ["web"], {"x": 1}, [{"category": "c", "title": "t", "severity": 0, "remediation": "", "details": ""}])
+        assert run_id > 0
+        runs = list_runs(db)
+        assert runs[0]["id"] == run_id
+        assert runs[0]["target"] == "example.com"

--- a/utils/history.py
+++ b/utils/history.py
@@ -1,0 +1,62 @@
+"""SQLite run history for MASAT."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from typing import Any
+
+
+def default_db_path() -> str:
+    base = os.path.join(os.path.expanduser("~"), ".masat")
+    os.makedirs(base, exist_ok=True)
+    return os.path.join(base, "masat.db")
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ts INTEGER NOT NULL,
+          target TEXT NOT NULL,
+          scans TEXT NOT NULL,
+          results_json TEXT NOT NULL,
+          findings_json TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def store_run(db_path: str, target: str, scans: list[str], results: dict[str, Any], findings: list[dict[str, Any]]) -> int:
+    conn = _connect(db_path)
+    try:
+        ts = int(time.time())
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO runs (ts, target, scans, results_json, findings_json) VALUES (?, ?, ?, ?, ?)",
+            (ts, target, json.dumps(scans), json.dumps(results), json.dumps(findings)),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+    finally:
+        conn.close()
+
+
+def list_runs(db_path: str, limit: int = 20) -> list[dict[str, Any]]:
+    conn = _connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT id, ts, target, scans FROM runs ORDER BY id DESC LIMIT ?", (limit,))
+        rows = cur.fetchall()
+        return [
+            {"id": r[0], "ts": r[1], "target": r[2], "scans": json.loads(r[3]) if r[3] else []}
+            for r in rows
+        ]
+    finally:
+        conn.close()

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -1,0 +1,67 @@
+"""Normalize MASAT results into a consistent schema for storage/UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Finding:
+    category: str
+    title: str
+    severity: int
+    remediation: str
+    details: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def normalize_findings(results: dict[str, Any]) -> list[Finding]:
+    findings: list[Finding] = []
+
+    for category, items in (results or {}).items():
+        if not isinstance(items, dict):
+            findings.append(
+                Finding(
+                    category=str(category),
+                    title="(value)",
+                    severity=0,
+                    remediation="",
+                    details=str(items),
+                )
+            )
+            continue
+
+        for title, det in items.items():
+            if isinstance(det, dict):
+                sev = det.get("severity", 0)
+                # allow non-int severities (e.g., nuclei severity strings)
+                try:
+                    sev_int = int(sev)
+                except Exception:
+                    # map common strings
+                    sev_int = {"info": 0, "low": 3, "medium": 5, "high": 7, "critical": 10}.get(str(sev).lower(), 0)
+
+                findings.append(
+                    Finding(
+                        category=str(category),
+                        title=str(title),
+                        severity=sev_int,
+                        remediation=str(det.get("remediation", "")),
+                        details=str(det.get("details", "")),
+                    )
+                )
+            else:
+                findings.append(
+                    Finding(
+                        category=str(category),
+                        title=str(title),
+                        severity=0,
+                        remediation="",
+                        details=str(det),
+                    )
+                )
+
+    return findings


### PR DESCRIPTION
### What
- Adds a normalized finding schema (category/title/severity/remediation/details)
- Adds optional local SQLite run history storage

### New flags
- --store: persist results to SQLite
- --db: override DB path (default: ~/.masat/masat.db)

### JSON output
- JSON output now includes a `findings` array (normalized across scanners) to make UI rendering and storage consistent.

### Why
This is a core building block for the UI portal and for comparing runs over time.