### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: tests
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/automatesecurity/masat/security/code-scanning/1](https://github.com/automatesecurity/masat/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Because this workflow only checks out the code and runs tests, it does not need write access to repository contents, issues, or pull requests, so `contents: read` is sufficient.

The best minimal change is to add a `permissions` block at the root of the workflow (top-level, alongside `name` and `on`) so it applies to all jobs that do not override it. In `.github/workflows/tests.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: tests` line and the `on:` block. No existing functionality changes: `actions/checkout@v4` continues to work with `contents: read`, and the rest of the steps only run local commands. No imports or additional methods are needed; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
