### PR TITLE
Fix: Nuclei severity aggregation + subprocess error reporting

### DIFF
--- a/tests/test_nuclei_scanner.py
+++ b/tests/test_nuclei_scanner.py
@@ -13,3 +13,42 @@ async def test_scan_returns_install_message_when_missing(monkeypatch):
     res = await nuclei_scanner.scan("https://example.com")
     assert "Nuclei" in res
     assert "nuclei not installed" in res["Nuclei"]
+
+
+@pytest.mark.asyncio
+async def test_scan_reports_failure_when_subprocess_fails(monkeypatch):
+    monkeypatch.setattr(nuclei_scanner, "_has_nuclei", lambda: True)
+
+    class DummyProc:
+        returncode = 2
+
+        async def communicate(self):
+            return b"", b"boom"
+
+    async def dummy_create(*args, **kwargs):
+        return DummyProc()
+
+    monkeypatch.setattr(nuclei_scanner.asyncio, "create_subprocess_exec", dummy_create)
+    res = await nuclei_scanner.scan("https://example.com")
+    assert "nuclei execution failed" in res["Nuclei"]
+
+
+@pytest.mark.asyncio
+async def test_scan_overall_severity_is_max_of_findings(monkeypatch):
+    monkeypatch.setattr(nuclei_scanner, "_has_nuclei", lambda: True)
+
+    class DummyProc:
+        returncode = 0
+
+        async def communicate(self):
+            # Two findings: low and critical
+            low = {"info": {"name": "A", "severity": "low"}, "matched-at": "x", "template": "t1"}
+            crit = {"info": {"name": "B", "severity": "critical"}, "matched-at": "y", "template": "t2"}
+            return (f"{__import__('json').dumps(low)}\n{__import__('json').dumps(crit)}\n").encode(), b""
+
+    async def dummy_create(*args, **kwargs):
+        return DummyProc()
+
+    monkeypatch.setattr(nuclei_scanner.asyncio, "create_subprocess_exec", dummy_create)
+    res = await nuclei_scanner.scan("https://example.com")
+    assert res["Nuclei"]["Nuclei findings"]["severity"] == 10


### PR DESCRIPTION
Closes #21. Closes #22.

### Fixes
- Overall severity is now derived as the max of Nuclei finding severities (info/low/medium/high/critical → 0/3/5/7/10).
- If the Nuclei subprocess fails (non-zero exit), MASAT now reports a "nuclei execution failed" finding instead of silently returning "no findings".

### Tests
- Added unit tests covering:
  - subprocess failure behavior
  - severity aggregation behavior
