### PR TITLE
Fix: guard URL port parsing against ValueError

### DIFF
--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,15 @@
+from utils.targets import parse_target
+
+
+def test_parse_target_url_invalid_port_does_not_crash():
+    info = parse_target("http://example.com:abc")
+    assert info.kind == "url"
+    assert info.host == "example.com"
+    assert info.port is None
+
+
+def test_parse_target_url_out_of_range_port_does_not_crash():
+    info = parse_target("https://example.com:99999")
+    assert info.kind == "url"
+    assert info.host == "example.com"
+    assert info.port is None

--- a/utils/targets.py
+++ b/utils/targets.py
@@ -22,7 +22,12 @@ def parse_target(target: str) -> TargetInfo:
 
     if parsed.scheme and parsed.hostname:
         host = parsed.hostname
-        return TargetInfo(raw=t, kind="url", host=host, scheme=parsed.scheme, port=parsed.port)
+        try:
+            port = parsed.port
+        except ValueError:
+            # urllib.parse raises ValueError for malformed/out-of-range ports
+            port = None
+        return TargetInfo(raw=t, kind="url", host=host, scheme=parsed.scheme, port=port)
 
     # CIDR?
     try:


### PR DESCRIPTION
Closes #24.

### Problem
urllib.parse can raise ValueError for malformed/out-of-range ports (e.g. http://example.com:abc).

### Fix
parse_target() now catches ValueError when reading parsed.port and normalizes to port=None.

### Tests
Added coverage for invalid and out-of-range ports.