### PR TITLE
Fix: lazy-load default DB path for --db

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -176,7 +176,7 @@ def main():
     )
     parser.add_argument(
         "--db",
-        default=default_db_path(),
+        default=None,
         help="SQLite DB path for --store (default: ~/.masat/masat.db).",
     )
 
@@ -285,9 +285,10 @@ def main():
     # Optional local history
     if args.store:
         normalized = [f.to_dict() for f in normalize_findings(results)]
-        run_id = store_run(args.db, args.target, sorted(list(scans)), results, normalized)
+        db_path = args.db or default_db_path()
+        run_id = store_run(db_path, args.target, sorted(list(scans)), results, normalized)
         if args.verbose:
-            print(f"Stored run in DB: {args.db} (id={run_id})")
+            print(f"Stored run in DB: {db_path} (id={run_id})")
 
     # Optional Slack notification
     if args.slack_webhook:

--- a/tests/test_db_default.py
+++ b/tests/test_db_default.py
@@ -1,0 +1,11 @@
+import os
+
+from utils.history import default_db_path
+
+
+def test_default_db_path_has_no_side_effects(tmp_path, monkeypatch):
+    # If default_db_path created ~/.masat eagerly, this would touch HOME.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = default_db_path()
+    assert p.endswith(os.path.join(".masat", "masat.db"))
+    assert not (tmp_path / ".masat").exists()

--- a/utils/history.py
+++ b/utils/history.py
@@ -10,12 +10,22 @@ from typing import Any
 
 
 def default_db_path() -> str:
+    """Return the default DB path (no side effects).
+
+    Note: do not create directories here. Only create the directory when the DB
+    is actually used (e.g., when --store is set).
+    """
+
     base = os.path.join(os.path.expanduser("~"), ".masat")
-    os.makedirs(base, exist_ok=True)
     return os.path.join(base, "masat.db")
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
+    # Ensure parent directory exists at time of use.
+    parent = os.path.dirname(os.path.abspath(db_path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
     conn = sqlite3.connect(db_path)
     conn.execute(
         """


### PR DESCRIPTION
Closes #25.

### Problem
default_db_path() created ~/.masat at import/argparse time via parser default evaluation.

### Fix
- default_db_path() is now side-effect free
- create the parent directory only when the DB is actually used
- argparse --db default is now None; resolved to default_db_path() only when --store is set

### Tests
Added a unit test ensuring default_db_path does not create directories.