### PR TITLE
Fix: address CodeQL high severity (uncontrolled path for DB directory creation)

### DIFF
--- a/tests/test_history_security.py
+++ b/tests/test_history_security.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+
+import pytest
+
+from utils.history import store_run
+
+
+def test_store_run_does_not_create_arbitrary_parent_dirs(tmp_path):
+    # If the parent directory doesn't exist and it's not the default MASAT dir,
+    # we should not auto-create it.
+    missing_parent = tmp_path / "does-not-exist"
+    db_path = missing_parent / "x.db"
+
+    with pytest.raises(Exception):
+        store_run(str(db_path), "t", ["web"], {"x": 1}, [])
+
+    assert not missing_parent.exists()

--- a/utils/history.py
+++ b/utils/history.py
@@ -22,8 +22,15 @@ def default_db_path() -> str:
 
 def _connect(db_path: str) -> sqlite3.Connection:
     # Ensure parent directory exists at time of use.
+    #
+    # IMPORTANT: `db_path` can be user-provided (CLI/API). Creating directories
+    # for arbitrary paths is an unsafe pattern and is flagged by CodeQL.
+    # We only auto-create the default MASAT DB directory; for any custom path,
+    # require the directory to already exist.
     parent = os.path.dirname(os.path.abspath(db_path))
-    if parent:
+    default_parent = os.path.dirname(os.path.abspath(default_db_path()))
+
+    if parent and os.path.commonpath([parent, default_parent]) == default_parent:
         os.makedirs(parent, exist_ok=True)
 
     conn = sqlite3.connect(db_path)


### PR DESCRIPTION
This fixes the CodeQL high-severity alert surfaced on PR #29.

### What changed
- utils.history._connect() no longer calls os.makedirs() for arbitrary user-provided DB paths.
- We only auto-create the default MASAT DB directory (~/.masat/). For custom --db paths, the parent directory must already exist.

### Why
CodeQL flags uncontrolled data used in a path expression (directory creation) as a high-severity issue.

### Tests
- Added a unit test ensuring we do not create missing parent directories for arbitrary DB paths.
