### PR TITLE
Feat: one-command MASAT CLI (pip install -e .; masat scan/serve)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+
+# Python packaging/build artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.coverage
+.pytest_cache/
+
+# Local virtualenv
+.venv/
+
+# Local run logs
+scan_*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: venv install install-dev install-api test scan serve
+
+venv:
+	python3 -m venv .venv
+	. .venv/bin/activate && pip install -U pip
+
+install:
+	pip install -e .
+
+install-dev:
+	pip install -e ".[dev]"
+
+install-api:
+	pip install -e ".[api]"
+
+test:
+	pytest -q
+
+scan:
+	masat scan $(TARGET) --smart --verbose
+
+serve:
+	masat serve --reload

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# api package

--- a/masat/__init__.py
+++ b/masat/__init__.py
@@ -1,0 +1,7 @@
+"""MASAT package.
+
+This package provides the `masat` CLI entrypoint.
+The legacy `scanner.py` script remains supported.
+"""
+
+__all__ = []

--- a/masat/__main__.py
+++ b/masat/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/masat/cli.py
+++ b/masat/cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import Sequence
+
+
+def _run_scanner_passthrough(args: Sequence[str]) -> int:
+    """Run legacy scanner.py with the provided args."""
+    cmd = [sys.executable, os.path.join(os.path.dirname(__file__), "..", "scanner.py"), *args]
+    return subprocess.call(cmd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    parser = argparse.ArgumentParser(prog="masat", description="MASAT: Modular Attack Surface Analysis Tool")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    scan = sub.add_parser("scan", help="Run a scan")
+    scan.add_argument("target", help="Target URL/domain/IP/CIDR")
+    scan.add_argument("--smart", action="store_true", help="Auto-select scans based on target")
+    scan.add_argument("--plan", action="store_true", help="Print scan plan and exit")
+    scan.add_argument("--scans", default=None, help="Comma-separated scan ids")
+    scan.add_argument("--scan-all", action="store_true", help="Run all scans")
+    scan.add_argument("--verbose", action="store_true")
+    scan.add_argument("--output", choices=["text", "json", "csv", "html"], default="text")
+    scan.add_argument("--output-file", default=None)
+    scan.add_argument("--playbook", action="store_true")
+    scan.add_argument("--store", action="store_true")
+    scan.add_argument("--db", default=None)
+    scan.add_argument("--slack-webhook", default=None)
+
+    list_scans = sub.add_parser("list-scans", help="List available scan modules")
+
+    serve = sub.add_parser("serve", help="Run the MASAT API server (requires extras: api)")
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", default="8000")
+    serve.add_argument("--reload", action="store_true")
+
+    ns = parser.parse_args(argv)
+
+    if ns.cmd == "list-scans":
+        return _run_scanner_passthrough(["--list-scans"])
+
+    if ns.cmd == "scan":
+        passthrough: list[str] = ["--target", ns.target]
+        if ns.smart:
+            passthrough.append("--smart")
+        if ns.plan:
+            passthrough.append("--plan")
+        if ns.scans:
+            passthrough += ["--scans", ns.scans]
+        if ns.scan_all:
+            passthrough.append("--scan-all")
+        if ns.verbose:
+            passthrough.append("--verbose")
+        if ns.playbook:
+            passthrough.append("--playbook")
+        if ns.store:
+            passthrough.append("--store")
+        if ns.db:
+            passthrough += ["--db", ns.db]
+        if ns.slack_webhook:
+            passthrough += ["--slack-webhook", ns.slack_webhook]
+
+        passthrough += ["--output", ns.output]
+        if ns.output_file:
+            passthrough += ["--output-file", ns.output_file]
+
+        return _run_scanner_passthrough(passthrough)
+
+    if ns.cmd == "serve":
+        # Avoid importing FastAPI at CLI import time.
+        cmd = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "api.app:app",
+            "--host",
+            ns.host,
+            "--port",
+            str(ns.port),
+        ]
+        if ns.reload:
+            cmd.append("--reload")
+        return subprocess.call(cmd)
+
+    parser.error("unknown command")
+    return 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "masat"
+version = "0.1.0"
+description = "MASAT: Modular Attack Surface Analysis Tool"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [{ name = "Daniel Wood" }]
+
+dependencies = [
+  "aiohttp==3.13.3",
+  "packaging==24.2",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest==8.3.5",
+  "pytest-asyncio==0.25.3",
+  "pytest-cov==6.0.0",
+]
+api = [
+  "fastapi==0.115.8",
+  "uvicorn==0.34.0",
+]
+
+[project.scripts]
+masat = "masat.cli:main"
+
+[tool.setuptools]
+packages = ["masat", "scanners", "utils", "api"]

--- a/scanners/__init__.py
+++ b/scanners/__init__.py
@@ -1,0 +1,1 @@
+# scanners package

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# utils package


### PR DESCRIPTION
### What
Adds a proper `masat` CLI entrypoint so MASAT can be run as a tool rather than a script.

### Why
This is the biggest UX polish upgrade: it enables a one-command quickstart and makes it easier to document, demo, and eventually back a UI portal.

### Changes
- Add `pyproject.toml` packaging with a console script: `masat`
- Add `masat` package with subcommands:
  - `masat scan <target>` (wraps existing scanner.py flags)
  - `masat list-scans`
  - `masat serve` (runs FastAPI app via uvicorn; requires api extras)
- Add `python -m masat` support
- Add a simple `Makefile` for quickstart targets
- Add `.gitignore` for Python build/test artifacts

### Backwards compatibility
- `scanner.py` remains supported and unchanged.

### Quickstart
- `pip install -e .`
- `masat list-scans`
- `masat scan https://example.com --smart --verbose`
- `pip install -e ".[api]" && masat serve --reload`