### PR TITLE
UI: polish portal (styling, better findings, run links)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ __pycache__/
 
 # Local run logs
 scan_*.log
+
+# UI build artifacts
+ui/node_modules/
+ui/.next/
+ui/out/
+ui/next-env.d.ts

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    // This repo has multiple lockfiles; explicitly pin the UI root to silence Next.js warnings.
+    root: __dirname,
+  },
 };
 
 export default nextConfig;

--- a/ui/src/app/page.module.css
+++ b/ui/src/app/page.module.css
@@ -1,141 +1,179 @@
-.page {
-  --background: #fafafa;
-  --foreground: #fff;
-
-  --text-primary: #000;
-  --text-secondary: #666;
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-  --button-secondary-border: #ebebeb;
-
-  display: flex;
-  min-height: 100vh;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-geist-sans);
-  background-color: var(--background);
-}
-
-.main {
-  display: flex;
-  min-height: 100vh;
-  width: 100%;
-  max-width: 800px;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: space-between;
-  background-color: var(--foreground);
-  padding: 120px 60px;
-}
-
-.intro {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  text-align: left;
-  gap: 24px;
-}
-
-.intro h1 {
-  max-width: 320px;
-  font-size: 40px;
-  font-weight: 600;
-  line-height: 48px;
-  letter-spacing: -2.4px;
-  text-wrap: balance;
-  color: var(--text-primary);
-}
-
-.intro p {
-  max-width: 440px;
-  font-size: 18px;
-  line-height: 32px;
-  text-wrap: balance;
-  color: var(--text-secondary);
-}
-
-.intro a {
-  font-weight: 500;
-  color: var(--text-primary);
-}
-
-.ctas {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  max-width: 440px;
-  gap: 16px;
-  font-size: 14px;
-}
-
-.ctas a {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
+.container {
+  max-width: 980px;
+  margin: 40px auto;
   padding: 0 16px;
-  border-radius: 128px;
-  border: 1px solid transparent;
-  transition: 0.2s;
-  cursor: pointer;
-  width: fit-content;
+  display: grid;
+  gap: 18px;
+}
+
+.header {
+  display: grid;
+  gap: 6px;
+}
+
+.title {
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: color-mix(in srgb, var(--foreground) 65%, transparent);
+  line-height: 1.4;
+}
+
+.card {
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  background: color-mix(in srgb, var(--background) 92%, var(--foreground) 8%);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.label {
+  display: grid;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.hint {
+  font-weight: 400;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--foreground) 60%, transparent);
+}
+
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  color: var(--foreground);
+}
+
+.row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.checkbox {
+  display: flex;
+  gap: 8px;
+  align-items: center;
   font-weight: 500;
 }
 
-a.primary {
-  background: var(--text-primary);
+.button {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  background: var(--foreground);
   color: var(--background);
+  font-weight: 700;
+  width: 140px;
+  cursor: pointer;
+}
+
+.button:hover {
+  opacity: 0.92;
+}
+
+.error {
+  border: 1px solid color-mix(in srgb, #cc3333 65%, transparent);
+  background: color-mix(in srgb, #cc3333 10%, var(--background));
+  color: #cc3333;
+}
+
+.sectionTitle {
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.meta {
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+}
+
+.badgeLow {
+  background: color-mix(in srgb, #2e7d32 12%, transparent);
+  color: #2e7d32;
+  border-color: color-mix(in srgb, #2e7d32 30%, transparent);
+}
+
+.badgeMed {
+  background: color-mix(in srgb, #b26a00 12%, transparent);
+  color: #b26a00;
+  border-color: color-mix(in srgb, #b26a00 30%, transparent);
+}
+
+.badgeHigh {
+  background: color-mix(in srgb, #c62828 12%, transparent);
+  color: #c62828;
+  border-color: color-mix(in srgb, #c62828 30%, transparent);
+}
+
+.finding {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+}
+
+.findingHeader {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.findingTitle {
+  font-weight: 800;
+}
+
+.kv {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.runs {
+  list-style: none;
+  display: grid;
   gap: 8px;
 }
 
-a.secondary {
-  border-color: var(--button-secondary-border);
+.runItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
 }
 
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-}
-
-@media (max-width: 600px) {
-  .main {
-    padding: 48px 24px;
-  }
-
-  .intro {
-    gap: 16px;
-  }
-
-  .intro h1 {
-    font-size: 32px;
-    line-height: 40px;
-    letter-spacing: -1.92px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
-  }
-
-  .page {
-    --background: #000;
-    --foreground: #000;
-
-    --text-primary: #ededed;
-    --text-secondary: #999;
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-    --button-secondary-border: #1a1a1a;
-  }
+.runLink {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--foreground) 35%, transparent);
 }

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,6 +1,17 @@
-import { runScan, fetchRuns } from "@/lib/masatApi";
+import { fetchScans, fetchRuns, runScan, type Finding } from "@/lib/masatApi";
+import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
+
+function sevLabel(sev: number): { label: string; cls: string } {
+  if (sev >= 8) return { label: "High", cls: styles.badgeHigh };
+  if (sev >= 4) return { label: "Medium", cls: styles.badgeMed };
+  return { label: "Low", cls: styles.badgeLow };
+}
+
+function bySeverityDesc(a: Finding, b: Finding) {
+  return (b.severity ?? 0) - (a.severity ?? 0);
+}
 
 export default async function Home({
   searchParams,
@@ -21,6 +32,11 @@ export default async function Home({
         ? smartParam.includes("1")
         : smartParam === "1";
 
+  const [availableScans, runs] = await Promise.all([
+    fetchScans().catch(() => []),
+    fetchRuns(20).catch(() => []),
+  ]);
+
   let scanResult: Awaited<ReturnType<typeof runScan>> | null = null;
   let scanError: string | null = null;
 
@@ -37,86 +53,164 @@ export default async function Home({
     }
   }
 
-  const runs = await fetchRuns(20).catch(() => []);
+  const findings = (scanResult?.findings || []).slice().sort(bySeverityDesc);
 
   return (
-    <main style={{ maxWidth: 980, margin: "40px auto", padding: "0 16px" }}>
-      <h1>MASAT Portal (Prototype)</h1>
-      <p style={{ color: "#444" }}>
-        Enter a URL, domain, IP, or CIDR. This UI calls the MASAT FastAPI server.
-      </p>
+    <main className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>MASAT Portal</h1>
+        <p className={styles.subtitle}>
+          Prototype UI for MASAT. Enter a URL, domain, IP, or CIDR; the UI calls the MASAT FastAPI server.
+        </p>
+      </header>
 
-      <form method="GET" style={{ display: "grid", gap: 12, marginTop: 16 }}>
-        <label>
-          Target
-          <input
-            name="target"
-            placeholder="https://example.com"
-            defaultValue={target}
-            style={{ width: "100%", padding: 10, marginTop: 6 }}
-          />
-        </label>
+      <section className={styles.card}>
+        <form method="GET" className={styles.form}>
+          <label className={styles.label}>
+            Target
+            <span className={styles.hint}>URL, domain, IP, or CIDR</span>
+            <input
+              className={styles.input}
+              name="target"
+              placeholder="https://example.com"
+              defaultValue={target}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </label>
 
-        <label>
-          Scans (comma-separated, optional)
-          <input
-            name="scans"
-            placeholder="web,tls,nuclei"
-            defaultValue={scans}
-            style={{ width: "100%", padding: 10, marginTop: 6 }}
-          />
-        </label>
+          <label className={styles.label}>
+            Scans
+            <span className={styles.hint}>
+              Optional comma-separated list (try: {availableScans.slice(0, 5).map((s) => s.id).join(", ")}
+              {availableScans.length > 5 ? ", …" : ""})
+            </span>
+            <input
+              className={styles.input}
+              name="scans"
+              placeholder="web,tls,nuclei"
+              defaultValue={scans}
+              list="scan-ids"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <datalist id="scan-ids">
+              {availableScans.map((s) => (
+                <option key={s.id} value={s.id} />
+              ))}
+            </datalist>
+          </label>
 
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <input type="checkbox" name="smart" value="1" defaultChecked={smartEnabled} />
-          Smart mode (auto-select scans)
-        </label>
+          <div className={styles.row}>
+            <label className={styles.checkbox}>
+              <input type="checkbox" name="smart" value="1" defaultChecked={smartEnabled} />
+              Smart mode (auto-select scans)
+            </label>
 
-        <button
-          type="submit"
-          name="run"
-          value="1"
-          style={{ padding: "10px 14px", width: 140 }}
-        >
-          Scan
-        </button>
-      </form>
+            <button type="submit" name="run" value="1" className={styles.button}>
+              Scan
+            </button>
+          </div>
+        </form>
+      </section>
 
       {scanError && (
-        <div style={{ marginTop: 24, padding: 12, border: "1px solid #c33", color: "#c33" }}>
+        <section className={`${styles.card} ${styles.error}`}>
           <strong>Scan failed:</strong> {scanError}
-        </div>
-      )}
-
-      {scanResult && (
-        <section style={{ marginTop: 24 }}>
-          <h2>Results</h2>
-          <p>
-            <strong>Target:</strong> {scanResult.target} | <strong>Run ID:</strong>{" "}
-            {String(scanResult.runId)}
-          </p>
-          <p>
-            <strong>Scans:</strong> {scanResult.scans?.join(", ")}
-          </p>
-
-          <h3>Findings</h3>
-          <pre style={{ whiteSpace: "pre-wrap", background: "#f6f6f6", padding: 12 }}>
-            {JSON.stringify(scanResult.findings, null, 2)}
-          </pre>
         </section>
       )}
 
-      <section style={{ marginTop: 28 }}>
-        <h2>Recent runs</h2>
-        <p style={{ color: "#666" }}>
-          Stored by the API server in SQLite (default: ~/.masat/masat.db).
+      {scanResult && (
+        <section className={styles.card}>
+          <h2 className={styles.sectionTitle}>Results</h2>
+          <div className={styles.meta}>
+            <div>
+              <strong>Target:</strong> {scanResult.target}
+            </div>
+            <div>
+              <strong>Run ID:</strong> {String(scanResult.runId)}
+            </div>
+            <div>
+              <strong>Scans:</strong> {scanResult.scans?.join(", ")}
+            </div>
+            <div>
+              <strong>Findings:</strong> {findings.length}
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gap: 10, marginTop: 12 }}>
+            {findings.length === 0 ? (
+              <div className={styles.meta}>No findings returned.</div>
+            ) : (
+              findings.map((f, idx) => {
+                const sev = sevLabel(f.severity ?? 0);
+                return (
+                  <div key={`${f.category}-${f.title}-${idx}`} className={styles.finding}>
+                    <div className={styles.findingHeader}>
+                      <span className={`${styles.badge} ${sev.cls}`}>{sev.label}</span>
+                      <span className={styles.findingTitle}>{f.title}</span>
+                      <span className={styles.meta}>({f.category})</span>
+                    </div>
+
+                    {f.details ? <div className={styles.meta}>{f.details}</div> : null}
+
+                    {f.remediation ? (
+                      <div className={styles.meta}>
+                        <strong>Remediation:</strong> {f.remediation}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <details style={{ marginTop: 14 }}>
+            <summary>Raw findings JSON</summary>
+            <pre className={styles.kv}>{JSON.stringify(scanResult.findings, null, 2)}</pre>
+          </details>
+        </section>
+      )}
+
+      <section className={styles.card}>
+        <h2 className={styles.sectionTitle}>Recent runs</h2>
+        <p className={styles.meta}>
+          Stored by the API server in SQLite (default: <code>~/.masat/masat.db</code>).
         </p>
-        <ul>
-          {runs.map((r) => (
-            <li key={r.id}>
-              #{r.id} — {r.target} — {new Date(r.ts * 1000).toLocaleString()} — [{r.scans.join(", ")}]
-            </li>
-          ))}
+
+        <ul className={styles.runs}>
+          {runs.map((r) => {
+            const qs = new URLSearchParams({
+              target: r.target,
+              scans: r.scans.join(","),
+              smart: "1",
+            });
+            const rerun = new URLSearchParams({
+              target: r.target,
+              scans: r.scans.join(","),
+              smart: "1",
+              run: "1",
+            });
+
+            return (
+              <li key={r.id} className={styles.runItem}>
+                <span>
+                  <strong>#{r.id}</strong> — {r.target} — {new Date(r.ts * 1000).toLocaleString()} — [
+                  {r.scans.join(", ")}]
+                </span>
+                <span style={{ display: "flex", gap: 12 }}>
+                  <a className={styles.runLink} href={`/?${qs.toString()}`}>
+                    Load
+                  </a>
+                  <a className={styles.runLink} href={`/?${rerun.toString()}`}>
+                    Run again
+                  </a>
+                </span>
+              </li>
+            );
+          })}
         </ul>
       </section>
     </main>


### PR DESCRIPTION
### What changed
- Replace inline styles with `page.module.css`
- Fetch `/scans` to provide scan ID suggestions (datalist)
- Render findings as sorted cards w/ severity badges + optional raw JSON
- Make recent runs actionable: Load + Run again links
- Ignore UI build artifacts (`ui/node_modules`, `ui/.next`, etc.)
- Silence Next.js workspace-root warning via `turbopack.root`

### Validation
- `pytest -q`
- `ui/`: `npm run lint` and `npm run build`