### PR TITLE
EASM: normalize findings schema v2 (asset + scanner + confidence + refs)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -91,7 +91,7 @@ async def scan(req: ScanRequest) -> dict[str, Any]:
         res = await reg[scan_id].scan(req.target, False)
         results.update(res)
 
-    findings = [f.to_dict() for f in normalize_findings(results)]
+    findings = [f.to_dict() for f in normalize_findings(results, asset=req.target)]
 
     run_id = None
     if req.store:

--- a/scanner.py
+++ b/scanner.py
@@ -241,7 +241,7 @@ def main():
     summary, synthesis, remediation = generate_summary(results)
 
     if args.output == "json":
-        normalized = [f.to_dict() for f in normalize_findings(results)]
+        normalized = [f.to_dict() for f in normalize_findings(results, asset=args.target)]
         payload = {
             "target": args.target,
             "scans": sorted(list(scans)),
@@ -284,7 +284,7 @@ def main():
 
     # Optional local history
     if args.store:
-        normalized = [f.to_dict() for f in normalize_findings(results)]
+        normalized = [f.to_dict() for f in normalize_findings(results, asset=args.target)]
         db_path = args.db or default_db_path()
         run_id = store_run(db_path, args.target, sorted(list(scans)), results, normalized)
         if args.verbose:

--- a/tests/test_schema_v2.py
+++ b/tests/test_schema_v2.py
@@ -1,0 +1,14 @@
+from utils.schema import normalize_findings
+
+
+def test_normalize_findings_includes_asset_and_scanner():
+    results = {
+        "Web Checks": {
+            "Header missing": {"severity": 5, "remediation": "Add header", "details": "x"}
+        }
+    }
+    findings = [f.to_dict() for f in normalize_findings(results, asset="example.com")]
+    assert findings and findings[0]["asset"] == "example.com"
+    assert findings[0]["scanner"] == "Web Checks"
+    assert "confidence" in findings[0]
+    assert "references" in findings[0]


### PR DESCRIPTION
Closes #41.

### What
Extends the normalized finding schema used for JSON output + history storage to include:
- `asset` (target)
- `scanner` (current top-level result category)
- `confidence` (default: unknown)
- `references` (default: [])

### Notes
- Backwards compatible for existing consumers: original fields remain.
- Call sites updated (CLI + API) to pass the target into normalization.

### Tests
- `pytest -q`