### PR TITLE
EASM: diff stored runs (new/resolved findings)

### DIFF
--- a/tests/test_diffing.py
+++ b/tests/test_diffing.py
@@ -1,0 +1,35 @@
+import os
+import tempfile
+
+from utils.history import store_run, get_run, list_runs_for_target
+from utils.diffing import diff_findings
+
+
+def test_diff_findings_added_and_resolved():
+    old = [
+        {"asset": "t", "category": "c", "title": "a"},
+        {"asset": "t", "category": "c", "title": "b"},
+    ]
+    new = [
+        {"asset": "t", "category": "c", "title": "b"},
+        {"asset": "t", "category": "c", "title": "d"},
+    ]
+
+    added, resolved = diff_findings(old, new)
+    assert [f["title"] for f in added] == ["d"]
+    assert [f["title"] for f in resolved] == ["a"]
+
+
+def test_history_get_run_and_list_runs_for_target():
+    with tempfile.TemporaryDirectory() as td:
+        db_path = os.path.join(td, "masat.db")
+        store_run(db_path, "example.com", ["web"], {"r": 1}, [{"asset": "example.com", "category": "c", "title": "a"}])
+        store_run(db_path, "example.com", ["web"], {"r": 2}, [{"asset": "example.com", "category": "c", "title": "b"}])
+
+        runs = list_runs_for_target(db_path, "example.com", limit=10)
+        assert len(runs) == 2
+
+        run = get_run(db_path, runs[0]["id"])
+        assert run and run["target"] == "example.com"
+        assert run["results"]
+        assert run["findings"]

--- a/utils/diffing.py
+++ b/utils/diffing.py
@@ -1,0 +1,47 @@
+"""Diff utilities for EASM.
+
+Focused on answering: what changed between two runs?
+
+We diff at two layers:
+- Findings: normalized finding tuples
+- Exposure-ish signals: attempt to detect open ports changes from raw results when available
+
+This is intentionally basic and evidence-preserving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class DiffResult:
+    target: str
+    old_run_id: int
+    new_run_id: int
+    new_findings: list[dict[str, Any]]
+    resolved_findings: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _finding_key(f: dict[str, Any]) -> tuple[str, str, str]:
+    # Use stable keys; tolerate schema changes.
+    asset = str(f.get("asset", ""))
+    category = str(f.get("category", ""))
+    title = str(f.get("title", ""))
+    return (asset, category, title)
+
+
+def diff_findings(old: Iterable[dict[str, Any]], new: Iterable[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    old_map = {_finding_key(f): f for f in (old or [])}
+    new_map = {_finding_key(f): f for f in (new or [])}
+
+    new_keys = set(new_map.keys())
+    old_keys = set(old_map.keys())
+
+    added = [new_map[k] for k in sorted(new_keys - old_keys)]
+    resolved = [old_map[k] for k in sorted(old_keys - new_keys)]
+    return added, resolved


### PR DESCRIPTION
Closes #43.

### What
Adds an EASM-oriented diff workflow for stored runs:
- `masat diff <target> [--last N] [--db PATH] [--output text|json]`

### Implementation
- New `utils.diffing` helper (diff normalized findings)
- History helpers: `list_runs_for_target`, `get_run`

### Tests
- `pytest -q` (includes new tests for diff + history helpers)