### PR TITLE
UI: runs table + run detail + exports (no rescan on refresh)

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -5,12 +5,6 @@ const nextConfig: NextConfig = {
     // This repo has multiple lockfiles; explicitly pin the UI root to silence Next.js warnings.
     root: __dirname,
   },
-
-  // Avoid dev-mode CORS/origin warnings when the dev server is accessed via 127.0.0.1.
-  // (Next config expects this under `experimental` in some versions.)
-  experimental: {
-    allowedDevOrigins: ["http://127.0.0.1:3005", "http://localhost:3005"],
-  },
 };
 
 export default nextConfig;

--- a/ui/src/app/_components/AppShell.tsx
+++ b/ui/src/app/_components/AppShell.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import styles from "./appShell.module.css";
+
+export default function AppShell({
+  active,
+  title,
+  subtitle,
+  pills,
+  children,
+}: {
+  active: "scan" | "runs";
+  title: string;
+  subtitle?: string;
+  pills?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className={styles.shell}>
+      <aside className={styles.sidebar}>
+        <div className={styles.brand}>
+          <div className={styles.logo} />
+          <div className={styles.brandText}>
+            <div className={styles.brandName}>MASAT</div>
+            <div className={styles.brandSub}>Attack surface signals</div>
+          </div>
+        </div>
+
+        <nav className={styles.nav} aria-label="Primary">
+          <Link
+            className={`${styles.navItem} ${active === "scan" ? styles.navItemActive : ""}`}
+            href="/"
+          >
+            Scan
+          </Link>
+          <Link
+            className={`${styles.navItem} ${active === "runs" ? styles.navItemActive : ""}`}
+            href="/runs"
+          >
+            Runs
+          </Link>
+        </nav>
+      </aside>
+
+      <main className={styles.content}>
+        <div className={styles.topbar}>
+          <div className={styles.pageTitle}>
+            <h1 className={styles.title}>{title}</h1>
+            {subtitle ? <p className={styles.subtitle}>{subtitle}</p> : null}
+          </div>
+
+          {pills ? <div className={styles.pills}>{pills}</div> : null}
+        </div>
+
+        <div className={styles.grid}>{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/app/_components/appShell.module.css
+++ b/ui/src/app/_components/appShell.module.css
@@ -1,0 +1,335 @@
+.shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 18px;
+  border-right: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(10px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.logo {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 1), rgba(34, 197, 94, 1));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.brandText {
+  display: grid;
+}
+
+.brandName {
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+.brandSub {
+  font-size: 12px;
+  color: var(--muted2);
+}
+
+.nav {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.navItem {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  color: var(--muted);
+}
+
+.navItem:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.navItemActive {
+  background: var(--panel);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.content {
+  padding: 22px 22px 60px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 8px 0 18px;
+}
+
+.pageTitle {
+  display: grid;
+  gap: 6px;
+}
+
+.title {
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--muted);
+  line-height: 1.4;
+  max-width: 62ch;
+}
+
+.pills {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.pill {
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  max-width: 1080px;
+}
+
+.card {
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius);
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sectionTitle {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.label {
+  display: grid;
+  gap: 6px;
+  font-weight: 700;
+}
+
+.hint {
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--muted2);
+}
+
+.input,
+.select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.20);
+  color: var(--text);
+  outline: none;
+}
+
+.input:focus,
+.select:focus {
+  border-color: rgba(124, 58, 237, 0.8);
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.18);
+}
+
+.row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.checkbox {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.button {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(124, 58, 237, 0.55);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 1), rgba(99, 102, 241, 1));
+  color: white;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.buttonSecondary {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.18);
+  color: rgba(255, 255, 255, 0.88);
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.button:hover,
+.buttonSecondary:hover {
+  filter: brightness(1.05);
+}
+
+.error {
+  border-color: rgba(239, 68, 68, 0.55);
+  background: rgba(239, 68, 68, 0.10);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.tableWrap {
+  width: 100%;
+  overflow: auto;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.table th,
+.table td {
+  padding: 12px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted2);
+}
+
+.table tr:hover td {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.actionLink {
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.28);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.actionLink:hover {
+  text-decoration-color: rgba(124, 58, 237, 0.85);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 800;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.badgeLow {
+  background: rgba(34, 197, 94, 0.12);
+  color: rgba(34, 197, 94, 0.95);
+  border-color: rgba(34, 197, 94, 0.25);
+}
+
+.badgeMed {
+  background: rgba(245, 158, 11, 0.12);
+  color: rgba(245, 158, 11, 0.95);
+  border-color: rgba(245, 158, 11, 0.25);
+}
+
+.badgeHigh {
+  background: rgba(239, 68, 68, 0.12);
+  color: rgba(239, 68, 68, 0.95);
+  border-color: rgba(239, 68, 68, 0.25);
+}
+
+.kv {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  margin-top: 10px;
+}
+
+@media (max-width: 900px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .pills {
+    justify-content: flex-start;
+  }
+}

--- a/ui/src/app/api/runs/[id]/export/json/route.ts
+++ b/ui/src/app/api/runs/[id]/export/json/route.ts
@@ -1,0 +1,28 @@
+function apiBase() {
+  return process.env.NEXT_PUBLIC_MASAT_API_BASE || "http://127.0.0.1:8000";
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const runId = Number(id);
+  if (!Number.isFinite(runId)) {
+    return new Response("Invalid run id", { status: 400 });
+  }
+
+  const res = await fetch(`${apiBase()}/runs/${runId}`, { cache: "no-store" });
+  if (!res.ok) {
+    return new Response(await res.text().catch(() => "Not found"), { status: res.status });
+  }
+
+  const data = await res.json();
+
+  return new Response(JSON.stringify(data, null, 2), {
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "content-disposition": `attachment; filename=masat-run-${runId}.json`,
+    },
+  });
+}

--- a/ui/src/app/api/runs/[id]/export/md/route.ts
+++ b/ui/src/app/api/runs/[id]/export/md/route.ts
@@ -1,0 +1,98 @@
+type Finding = {
+  category?: string;
+  title?: string;
+  severity?: number;
+  details?: string;
+  remediation?: string;
+};
+
+type RunDetail = {
+  id: number;
+  ts: number;
+  target: string;
+  scans: string[];
+  findings: Finding[];
+};
+
+function apiBase() {
+  return process.env.NEXT_PUBLIC_MASAT_API_BASE || "http://127.0.0.1:8000";
+}
+
+function sevLabel(sev: number): "High" | "Medium" | "Low" {
+  if (sev >= 8) return "High";
+  if (sev >= 4) return "Medium";
+  return "Low";
+}
+
+function toMarkdown(run: RunDetail) {
+  const findings = (run.findings || []).slice().sort((a, b) => (b.severity ?? 0) - (a.severity ?? 0));
+
+  const lines: string[] = [];
+  lines.push(`# MASAT Run #${run.id}`);
+  lines.push("");
+  lines.push(`- **Target:** ${run.target}`);
+  lines.push(`- **Timestamp:** ${new Date(run.ts * 1000).toISOString()}`);
+  lines.push(`- **Scans:** ${(run.scans || []).join(", ") || "(none)"}`);
+  lines.push(`- **Findings:** ${findings.length}`);
+  lines.push("");
+
+  if (findings.length === 0) {
+    lines.push("No findings.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push("## Findings");
+  lines.push("");
+
+  findings.forEach((f, idx) => {
+    const sev = sevLabel(f.severity ?? 0);
+    const title = f.title || "(untitled)";
+    const cat = f.category ? ` (${f.category})` : "";
+
+    lines.push(`### ${idx + 1}. [${sev}] ${title}${cat}`);
+    if (f.details) {
+      lines.push("");
+      lines.push(f.details);
+    }
+    if (f.remediation) {
+      lines.push("");
+      lines.push("**Remediation:**");
+      lines.push("");
+      lines.push(f.remediation);
+    }
+    lines.push("");
+  });
+
+  return lines.join("\n");
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const runId = Number(id);
+  if (!Number.isFinite(runId)) {
+    return new Response("Invalid run id", { status: 400 });
+  }
+
+  const res = await fetch(`${apiBase()}/runs/${runId}`, { cache: "no-store" });
+  if (!res.ok) {
+    return new Response(await res.text().catch(() => "Not found"), { status: res.status });
+  }
+
+  const data = (await res.json()) as { run?: RunDetail };
+  if (!data?.run) {
+    return new Response("Malformed API response", { status: 502 });
+  }
+
+  const md = toMarkdown(data.run);
+
+  return new Response(md, {
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      "content-disposition": `attachment; filename=masat-run-${runId}.md`,
+    },
+  });
+}

--- a/ui/src/app/api/scan/route.ts
+++ b/ui/src/app/api/scan/route.ts
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+
+function apiBase() {
+  return process.env.NEXT_PUBLIC_MASAT_API_BASE || "http://127.0.0.1:8000";
+}
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const target = String(form.get("target") || "").trim();
+  const scans = String(form.get("scans") || "").trim();
+  const smart = form.get("smart") === "1";
+
+  if (!target) {
+    redirect(`/?error=${encodeURIComponent("Missing target")}`);
+  }
+
+  try {
+    const res = await fetch(`${apiBase()}/scan`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        target,
+        scans: scans ? scans : null,
+        smart,
+        store: true,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      redirect(`/?error=${encodeURIComponent(`MASAT /scan failed: ${res.status} ${text}`)}`);
+    }
+
+    const data: unknown = await res.json();
+    const runId = (data as { runId?: number | null } | null)?.runId ?? null;
+
+    if (typeof runId === "number") {
+      redirect(`/runs/${runId}`);
+    }
+
+    redirect(`/?error=${encodeURIComponent("Scan completed but was not stored (runId missing).")}`);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    redirect(`/?error=${encodeURIComponent(msg)}`);
+  }
+}

--- a/ui/src/app/runs/[id]/page.tsx
+++ b/ui/src/app/runs/[id]/page.tsx
@@ -1,0 +1,127 @@
+import AppShell from "@/app/_components/AppShell";
+import styles from "@/app/_components/appShell.module.css";
+import { fetchRun, type Finding } from "@/lib/masatApi";
+
+export const dynamic = "force-dynamic";
+
+function sevLabel(sev: number): { label: string; cls: string } {
+  if (sev >= 8) return { label: "High", cls: styles.badgeHigh };
+  if (sev >= 4) return { label: "Medium", cls: styles.badgeMed };
+  return { label: "Low", cls: styles.badgeLow };
+}
+
+function bySeverityDesc(a: Finding, b: Finding) {
+  return (b.severity ?? 0) - (a.severity ?? 0);
+}
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const runId = Number(id);
+
+  const run = await fetchRun(runId);
+  const findings = (run.findings || []).slice().sort(bySeverityDesc);
+
+  return (
+    <AppShell
+      active="runs"
+      title={`Run #${run.id}`}
+      subtitle={`Target: ${run.target}`}
+      pills={
+        <>
+          <span className={styles.pill}>{new Date(run.ts * 1000).toLocaleString()}</span>
+          <span className={styles.pill}>Scans: {(run.scans || []).length}</span>
+          <span className={styles.pill}>Findings: {findings.length}</span>
+        </>
+      }
+    >
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Summary</div>
+          <div className={styles.actions}>
+            <a className={styles.actionLink} href={`/api/runs/${run.id}/export/json`}>
+              Export JSON
+            </a>
+            <a className={styles.actionLink} href={`/api/runs/${run.id}/export/md`}>
+              Export Markdown
+            </a>
+          </div>
+        </div>
+
+        <div className={styles.meta}>
+          <div>
+            <strong>Target:</strong> {run.target}
+          </div>
+          <div>
+            <strong>Scans:</strong> {(run.scans || []).join(", ") || "(none)"}
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Findings</div>
+          <div className={styles.meta}>Sorted by severity</div>
+        </div>
+
+        {findings.length === 0 ? (
+          <div className={styles.meta}>No findings returned.</div>
+        ) : (
+          <div className={styles.tableWrap}>
+            <table className={styles.table} style={{ minWidth: 900 }}>
+              <thead>
+                <tr>
+                  <th style={{ width: 120 }}>Severity</th>
+                  <th>Title</th>
+                  <th style={{ width: 170 }}>Category</th>
+                </tr>
+              </thead>
+              <tbody>
+                {findings.map((f, idx) => {
+                  const sev = sevLabel(f.severity ?? 0);
+                  return (
+                    <tr key={`${f.category}-${f.title}-${idx}`}>
+                      <td>
+                        <span className={`${styles.badge} ${sev.cls}`}>{sev.label}</span>
+                      </td>
+                      <td>
+                        <div style={{ fontWeight: 900 }}>{f.title}</div>
+                        {f.details ? <div className={styles.meta}>{f.details}</div> : null}
+                        {f.remediation ? (
+                          <div className={styles.meta}>
+                            <strong>Remediation:</strong> {f.remediation}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className={styles.meta}>{f.category}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Raw data</div>
+          <div className={styles.meta}>As stored in SQLite</div>
+        </div>
+
+        <details>
+          <summary className={styles.meta}>Results JSON</summary>
+          <pre className={styles.kv}>{JSON.stringify(run.results, null, 2)}</pre>
+        </details>
+
+        <details style={{ marginTop: 10 }}>
+          <summary className={styles.meta}>Findings JSON</summary>
+          <pre className={styles.kv}>{JSON.stringify(run.findings, null, 2)}</pre>
+        </details>
+      </section>
+    </AppShell>
+  );
+}

--- a/ui/src/app/runs/page.tsx
+++ b/ui/src/app/runs/page.tsx
@@ -1,0 +1,146 @@
+import AppShell from "@/app/_components/AppShell";
+import styles from "@/app/_components/appShell.module.css";
+import { fetchRuns, fetchScans } from "@/lib/masatApi";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export default async function RunsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = (await searchParams) || {};
+  const q = typeof sp.q === "string" ? sp.q.trim() : "";
+  const scan = typeof sp.scan === "string" ? sp.scan.trim() : "";
+  const limitRaw = typeof sp.limit === "string" ? sp.limit : "100";
+  const limit = Math.max(1, Math.min(500, Number(limitRaw) || 100));
+
+  const [runs, availableScans] = await Promise.all([
+    fetchRuns(limit).catch(() => []),
+    fetchScans().catch(() => []),
+  ]);
+
+  const filtered = runs.filter((r) => {
+    if (q) {
+      const hay = `${r.target} ${r.id}`.toLowerCase();
+      if (!hay.includes(q.toLowerCase())) return false;
+    }
+    if (scan) {
+      if (!r.scans.includes(scan)) return false;
+    }
+    return true;
+  });
+
+  return (
+    <AppShell
+      active="runs"
+      title="Runs"
+      subtitle="Browse stored scan runs. Filter by target or scan type, drill in for findings, and export." 
+      pills={
+        <>
+          <span className={styles.pill}>Total loaded: {runs.length}</span>
+          <span className={styles.pill}>Showing: {filtered.length}</span>
+        </>
+      }
+    >
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Filters</div>
+          <div className={styles.meta}>These are client-side filters (no rescans).</div>
+        </div>
+
+        <form method="GET" className={styles.form}>
+          <div className={styles.row}>
+            <label className={styles.label} style={{ flex: 1, minWidth: 260 }}>
+              Search
+              <span className={styles.hint}>Target substring or run id</span>
+              <input className={styles.input} name="q" placeholder="example.com" defaultValue={q} />
+            </label>
+
+            <label className={styles.label} style={{ minWidth: 220 }}>
+              Scan
+              <span className={styles.hint}>Only runs that include this scan</span>
+              <select className={styles.select} name="scan" defaultValue={scan}>
+                <option value="">All scans</option>
+                {availableScans.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className={styles.label} style={{ minWidth: 160 }}>
+              Limit
+              <span className={styles.hint}>Max rows fetched</span>
+              <input className={styles.input} name="limit" defaultValue={String(limit)} />
+            </label>
+
+            <div className={styles.row} style={{ alignSelf: "end" }}>
+              <button className={styles.buttonSecondary} type="submit">
+                Apply
+              </button>
+              <Link className={styles.actionLink} href="/runs">
+                Reset
+              </Link>
+            </div>
+          </div>
+        </form>
+      </section>
+
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Run history</div>
+          <div className={styles.meta}>Click a run to view full results and findings.</div>
+        </div>
+
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th style={{ width: 86 }}>Run</th>
+                <th>Target</th>
+                <th style={{ width: 210 }}>Time</th>
+                <th>Scans</th>
+                <th style={{ width: 260 }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <strong>#{r.id}</strong>
+                  </td>
+                  <td>{r.target}</td>
+                  <td>{new Date(r.ts * 1000).toLocaleString()}</td>
+                  <td className={styles.meta}>{r.scans.join(", ")}</td>
+                  <td>
+                    <div className={styles.actions}>
+                      <a className={styles.actionLink} href={`/runs/${r.id}`}>
+                        View
+                      </a>
+                      <a className={styles.actionLink} href={`/api/runs/${r.id}/export/json`}>
+                        JSON
+                      </a>
+                      <a className={styles.actionLink} href={`/api/runs/${r.id}/export/md`}>
+                        Markdown
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className={styles.meta}>
+                    No runs match your filters.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </AppShell>
+  );
+}

--- a/ui/src/lib/masatApi.ts
+++ b/ui/src/lib/masatApi.ts
@@ -1,6 +1,12 @@
 export type Scan = { id: string; description?: string };
 export type RunRow = { id: number; ts: number; target: string; scans: string[] };
 
+export type RunDetail = RunRow & {
+  // API shape from GET /runs/{id}
+  results: unknown;
+  findings: Finding[];
+};
+
 export type Finding = {
   category: string;
   title: string;
@@ -34,6 +40,13 @@ export async function fetchRuns(limit = 20): Promise<RunRow[]> {
   if (!res.ok) throw new Error(`MASAT /runs failed: ${res.status}`);
   const data = await res.json();
   return data.runs || [];
+}
+
+export async function fetchRun(id: number): Promise<RunDetail> {
+  const res = await fetch(`${baseUrl()}/runs/${id}`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`MASAT /runs/${id} failed: ${res.status}`);
+  const data = await res.json();
+  return data.run as RunDetail;
 }
 
 export async function runScan(params: {


### PR DESCRIPTION
Closes #42. Closes #45.

### What
Turns the UI into a usable EASM portal:
- Scan flow is now **POST → store → redirect to run detail**, so refreshing is safe.
- Adds a Runs table and a per-run detail view.
- Adds exports: download JSON + Markdown report.

### API
- Adds `GET /runs/{id}` for full run detail.

### Validation
- `pytest -q`
- `ui/`: `npm run lint` and `npm run build`