### PR TITLE
EASM: asset inventory + scoping (import/list + scope check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ masat scan https://example.com --smart --store --output json > run.json
 masat diff https://example.com
 ```
 
-5) **Browse** results in the UI:
+5) **Scope-check** a target before scanning:
+```bash
+masat scope check https://example.com --allow-domain example.com
+```
+
+6) **Browse** results in the UI:
 ```bash
 pip install -e ".[api]"
 masat serve --reload

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,29 @@
+from utils.assets import ScopeConfig, in_scope
+
+
+def test_scope_allows_subdomains():
+    scope = ScopeConfig(allow_domains=["example.com"], allow_cidrs=[], deny_patterns=[])
+    assert in_scope("https://a.example.com", scope)[0] is True
+    assert in_scope("b.example.com", scope)[0] is True
+    assert in_scope("example.com", scope)[0] is True
+
+
+def test_scope_denies_by_pattern():
+    scope = ScopeConfig(
+        allow_domains=["example.com"],
+        allow_cidrs=[],
+        deny_patterns=["*admin*"],
+    )
+    assert in_scope("admin.example.com", scope)[0] is False
+
+
+def test_scope_allows_ip_in_cidr():
+    scope = ScopeConfig(allow_domains=[], allow_cidrs=["10.0.0.0/8"], deny_patterns=[])
+    assert in_scope("10.1.2.3", scope)[0] is True
+    assert in_scope("8.8.8.8", scope)[0] is False
+
+
+def test_scope_allows_cidr_subset_only():
+    scope = ScopeConfig(allow_domains=[], allow_cidrs=["10.0.0.0/8"], deny_patterns=[])
+    assert in_scope("10.1.0.0/16", scope)[0] is True
+    assert in_scope("0.0.0.0/0", scope)[0] is False

--- a/utils/assets.py
+++ b/utils/assets.py
@@ -1,0 +1,254 @@
+"""Local asset inventory + scoping helpers (EASM).
+
+Design goals:
+- Safe-by-default: explicit allowlist roots + optional denylist
+- Minimal dependencies (stdlib)
+- SQLite-backed to support UI later
+
+This is a first pass meant to unlock EASM workflows.
+"""
+
+from __future__ import annotations
+
+import csv
+import fnmatch
+import ipaddress
+import os
+import sqlite3
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Iterable
+
+from utils.targets import parse_target
+
+
+@dataclass(frozen=True)
+class Asset:
+    kind: str  # host|ip|url|cidr
+    value: str
+    tags: list[str]
+    owner: str
+    environment: str
+    ts: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def default_assets_db_path() -> str:
+    base = os.path.join(os.path.expanduser("~"), ".masat")
+    return os.path.join(base, "assets.db")
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    parent = os.path.dirname(os.path.abspath(db_path))
+    default_parent = os.path.dirname(os.path.abspath(default_assets_db_path()))
+    if parent and os.path.commonpath([parent, default_parent]) == default_parent:
+        os.makedirs(parent, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS assets (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ts INTEGER NOT NULL,
+          kind TEXT NOT NULL,
+          value TEXT NOT NULL,
+          tags TEXT NOT NULL,
+          owner TEXT NOT NULL,
+          environment TEXT NOT NULL,
+          UNIQUE(kind, value)
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def upsert_asset(db_path: str, asset: Asset) -> None:
+    conn = _connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT OR REPLACE INTO assets (ts, kind, value, tags, owner, environment) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                int(asset.ts),
+                asset.kind,
+                asset.value,
+                ",".join(asset.tags),
+                asset.owner,
+                asset.environment,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def list_assets(db_path: str, limit: int = 200) -> list[Asset]:
+    conn = _connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT ts, kind, value, tags, owner, environment FROM assets ORDER BY value ASC LIMIT ?",
+            (int(limit),),
+        )
+        rows = cur.fetchall()
+        out: list[Asset] = []
+        for ts, kind, value, tags, owner, environment in rows:
+            out.append(
+                Asset(
+                    ts=int(ts),
+                    kind=str(kind),
+                    value=str(value),
+                    tags=[t for t in str(tags or "").split(",") if t],
+                    owner=str(owner or ""),
+                    environment=str(environment or ""),
+                )
+            )
+        return out
+    finally:
+        conn.close()
+
+
+def import_assets_csv(
+    db_path: str,
+    csv_path: str,
+    *,
+    default_owner: str = "",
+    default_environment: str = "",
+) -> int:
+    """Import assets from CSV.
+
+    CSV columns (case-insensitive):
+    - asset (or value)
+    - kind (optional; inferred if missing)
+    - tags (comma-separated; optional)
+    - owner (optional)
+    - environment (optional)
+    """
+
+    n = 0
+    now = int(time.time())
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if not reader.fieldnames:
+            return 0
+
+        # normalize headers
+        def get(row: dict[str, str], *names: str) -> str:
+            for name in names:
+                for k in row.keys():
+                    if k and k.strip().lower() == name:
+                        return (row.get(k) or "").strip()
+            return ""
+
+        for row in reader:
+            value = get(row, "asset") or get(row, "value")
+            if not value:
+                continue
+
+            kind = get(row, "kind")
+            if not kind:
+                info = parse_target(value)
+                kind = info.kind
+
+            tags_raw = get(row, "tags")
+            tags = [t.strip() for t in tags_raw.split(",") if t.strip()]
+            owner = get(row, "owner") or default_owner
+            env = get(row, "environment") or default_environment
+
+            upsert_asset(
+                db_path,
+                Asset(kind=str(kind), value=value.strip(), tags=tags, owner=owner, environment=env, ts=now),
+            )
+            n += 1
+
+    return n
+
+
+@dataclass(frozen=True)
+class ScopeConfig:
+    allow_domains: list[str]
+    allow_cidrs: list[str]
+    deny_patterns: list[str]
+
+
+def _host_in_allowed_domains(host: str, allow_domains: Iterable[str]) -> bool:
+    h = (host or "").strip().lower().rstrip(".")
+    if not h:
+        return False
+
+    for d0 in allow_domains:
+        d = (d0 or "").strip().lower().rstrip(".")
+        if not d:
+            continue
+        if h == d or h.endswith("." + d):
+            return True
+    return False
+
+
+def _ip_in_allowed_cidrs(ip: str, allow_cidrs: Iterable[str]) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except Exception:
+        return False
+
+    for c in allow_cidrs:
+        try:
+            net = ipaddress.ip_network(str(c), strict=False)
+        except Exception:
+            continue
+        if addr in net:
+            return True
+    return False
+
+
+def _matches_any_pattern(value: str, patterns: Iterable[str]) -> bool:
+    v = (value or "").strip().lower()
+    for p0 in patterns:
+        p = (p0 or "").strip().lower()
+        if not p:
+            continue
+        if fnmatch.fnmatch(v, p):
+            return True
+    return False
+
+
+def in_scope(target: str, scope: ScopeConfig) -> tuple[bool, str]:
+    """Return (allowed, reason)."""
+
+    info = parse_target(target)
+
+    if _matches_any_pattern(info.raw, scope.deny_patterns):
+        return False, "Denied by pattern"
+
+    if info.kind == "cidr":
+        # only allow CIDR if it is fully within at least one allowed CIDR
+        try:
+            net = ipaddress.ip_network(info.raw, strict=False)
+        except Exception:
+            return False, "Invalid CIDR"
+
+        for c in scope.allow_cidrs:
+            try:
+                allow_net = ipaddress.ip_network(str(c), strict=False)
+            except Exception:
+                continue
+            if net.subnet_of(allow_net):
+                return True, "CIDR allowed"
+
+        return False, "CIDR not in allowlist"
+
+    if info.kind == "ip":
+        if _ip_in_allowed_cidrs(info.host or "", scope.allow_cidrs):
+            return True, "IP allowed"
+        return False, "IP not in allowlist"
+
+    # url or host
+    host = info.host or ""
+    if _host_in_allowed_domains(host, scope.allow_domains):
+        return True, "Domain allowed"
+
+    return False, "Domain not in allowlist"


### PR DESCRIPTION
Closes #51.

### What
Adds first-class EASM helpers:
- `masat assets import <csv>` (SQLite-backed inventory)
- `masat assets list`
- `masat scope check <target> --allow-domain ... --allow-cidr ... --deny ...`

### Safety
- Scope evaluation supports allowlist roots and deny patterns.
- CIDR targets are only allowed if they are a subset of an allowed CIDR.

### Tests
- `pytest -q` (includes scope matching tests)

### Docs
- README includes scope-check example.