### PR TITLE
EASM: exposure-aware diff (ports + server header changes)

### DIFF
--- a/utils/diffing.py
+++ b/utils/diffing.py
@@ -15,13 +15,102 @@ from dataclasses import dataclass, asdict
 from typing import Any, Iterable
 
 
+def _parse_nmap_open_ports_table(details: str) -> set[str]:
+    """Parse the human-readable nmap table into stable port identifiers.
+
+    Returns a set of strings like: "22/tcp ssh" or "443/tcp https".
+    """
+
+    s = (details or "").strip("\n")
+    if not s or "No open ports" in s:
+        return set()
+
+    lines = [ln.rstrip() for ln in s.splitlines() if ln.strip()]
+    if len(lines) < 3:
+        return set()
+
+    # Expect header + separator then data rows.
+    data = lines[2:]
+    ports: set[str] = set()
+    for ln in data:
+        parts = ln.split()
+        if not parts:
+            continue
+        port = parts[0]
+        service = parts[1] if len(parts) > 1 else ""
+        ports.add(f"{port} {service}".strip())
+
+    return ports
+
+
+def _extract_server_header(results: dict[str, Any]) -> str | None:
+    try:
+        tech = results.get("Web Server Technology")
+        if not isinstance(tech, dict):
+            return None
+        det = tech.get("Detected Server")
+        if not isinstance(det, dict):
+            return None
+        details = str(det.get("details", ""))
+        # e.g. "Server header: nginx"
+        if ":" in details:
+            return details.split(":", 1)[1].strip() or None
+        return details.strip() or None
+    except Exception:
+        return None
+
+
+def extract_exposure(results: dict[str, Any]) -> dict[str, Any]:
+    """Extract exposure-ish signals from raw scanner results."""
+
+    nmap = (results or {}).get("Nmap Scan") or {}
+    ports_entry = (nmap.get("\nOpen Ports") if isinstance(nmap, dict) else {}) or {}
+    details = ports_entry.get("details", "") if isinstance(ports_entry, dict) else ""
+
+    exposure: dict[str, Any] = {
+        "open_ports": sorted(list(_parse_nmap_open_ports_table(str(details)))),
+    }
+
+    server = _extract_server_header(results or {})
+    if server:
+        exposure["server_header"] = server
+
+    return exposure
+
+
+def diff_exposure(old_results: dict[str, Any], new_results: dict[str, Any]) -> dict[str, Any]:
+    old = extract_exposure(old_results or {})
+    new = extract_exposure(new_results or {})
+
+    old_ports = set(old.get("open_ports") or [])
+    new_ports = set(new.get("open_ports") or [])
+
+    out: dict[str, Any] = {
+        "added_ports": sorted(list(new_ports - old_ports)),
+        "removed_ports": sorted(list(old_ports - new_ports)),
+    }
+
+    if old.get("server_header") != new.get("server_header"):
+        out["server_header"] = {
+            "old": old.get("server_header"),
+            "new": new.get("server_header"),
+        }
+
+    return out
+
+
 @dataclass(frozen=True)
 class DiffResult:
     target: str
     old_run_id: int
     new_run_id: int
+
+    # Findings layer
     new_findings: list[dict[str, Any]]
     resolved_findings: list[dict[str, Any]]
+
+    # Exposure layer (ports/fingerprints)
+    exposure: dict[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)


### PR DESCRIPTION
Closes #53.

### What
Enhances `masat diff` to detect exposure changes in addition to normalized finding changes:
- Added/removed open ports (parsed from Nmap output)
- Server fingerprint changes (Server header)

### Output
- JSON includes `exposure` section
- Text mode prints exposure deltas before findings

### Tests
- `pytest -q` includes fixtures for port + server header diffs