### PR TITLE
UI: Assets page + saved views (EASM)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -28,7 +28,8 @@ from scanners.registry import discover_scanners
 from utils.targets import parse_target
 from utils.workflows import plan_scans
 from utils.schema import normalize_findings
-from utils.history import default_db_path, store_run, list_runs
+from utils.history import default_db_path, store_run, list_runs, get_run
+from utils.assets import default_assets_db_path, list_assets
 
 
 app = FastAPI(title="MASAT API", version="0.1")
@@ -105,3 +106,19 @@ async def scan(req: ScanRequest) -> dict[str, Any]:
 def runs(limit: int = 20, db: str | None = None) -> dict[str, Any]:
     db_path = db or default_db_path()
     return {"runs": list_runs(db_path, limit=limit)}
+
+
+@app.get("/runs/{run_id}")
+def run_detail(run_id: int, db: str | None = None) -> dict[str, Any]:
+    db_path = db or default_db_path()
+    run = get_run(db_path, run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return {"run": run}
+
+
+@app.get("/assets")
+def assets(limit: int = 200, db: str | None = None) -> dict[str, Any]:
+    db_path = db or default_assets_db_path()
+    rows = [a.to_dict() for a in list_assets(db_path, limit=limit)]
+    return {"assets": rows}

--- a/ui/src/app/_components/AppShell.tsx
+++ b/ui/src/app/_components/AppShell.tsx
@@ -9,7 +9,7 @@ export default function AppShell({
   pills,
   children,
 }: {
-  active: "scan" | "runs";
+  active: "scan" | "runs" | "assets";
   title: string;
   subtitle?: string;
   pills?: ReactNode;
@@ -38,6 +38,12 @@ export default function AppShell({
             href="/runs"
           >
             Runs
+          </Link>
+          <Link
+            className={`${styles.navItem} ${active === "assets" ? styles.navItemActive : ""}`}
+            href="/assets"
+          >
+            Assets
           </Link>
         </nav>
       </aside>

--- a/ui/src/app/assets/page.tsx
+++ b/ui/src/app/assets/page.tsx
@@ -1,0 +1,136 @@
+import AppShell from "@/app/_components/AppShell";
+import styles from "@/app/_components/appShell.module.css";
+import { fetchAssets, type AssetRow } from "@/lib/masatApi";
+
+export const dynamic = "force-dynamic";
+
+function uniq(items: string[]) {
+  return Array.from(new Set(items)).sort();
+}
+
+function matches(asset: AssetRow, q: string) {
+  const s = q.toLowerCase().trim();
+  if (!s) return true;
+  return (
+    asset.value.toLowerCase().includes(s) ||
+    asset.kind.toLowerCase().includes(s) ||
+    (asset.owner || "").toLowerCase().includes(s) ||
+    (asset.environment || "").toLowerCase().includes(s) ||
+    (asset.tags || []).join(",").toLowerCase().includes(s)
+  );
+}
+
+export default async function AssetsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = (await searchParams) || {};
+  const q = typeof sp.q === "string" ? sp.q : "";
+  const view = typeof sp.view === "string" ? sp.view : "";
+
+  const assets = await fetchAssets(500).catch(() => []);
+
+  const allTags = uniq(assets.flatMap((a) => a.tags || []));
+  const allEnvs = uniq(assets.map((a) => a.environment || "").filter(Boolean));
+
+  // Very simple saved views (server-side presets via ?view=...)
+  const viewFilter = (a: AssetRow) => {
+    if (view === "prod") return (a.environment || "").toLowerCase() === "prod";
+    if (view === "internet") return (a.tags || []).map((t) => t.toLowerCase()).includes("internet-facing");
+    return true;
+  };
+
+  const filtered = assets.filter((a) => viewFilter(a)).filter((a) => matches(a, q));
+
+  return (
+    <AppShell
+      active="assets"
+      title="Assets"
+      subtitle="Local asset inventory (EASM). Import via CLI, browse/filter here."
+      pills={
+        <>
+          <span className={styles.pill}>Total: {assets.length}</span>
+          <span className={styles.pill}>Filtered: {filtered.length}</span>
+          <span className={styles.pill}>Tags: {allTags.length}</span>
+          <span className={styles.pill}>Envs: {allEnvs.length}</span>
+        </>
+      }
+    >
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Saved views</div>
+          <div className={styles.meta}>Lightweight presets (we can add user-saved views next)</div>
+        </div>
+
+        <div className={styles.actions}>
+          <a className={styles.actionLink} href="/assets">
+            All assets
+          </a>
+          <a className={styles.actionLink} href="/assets?view=prod">
+            Prod
+          </a>
+          <a className={styles.actionLink} href="/assets?view=internet">
+            Internet-facing
+          </a>
+        </div>
+      </section>
+
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Search</div>
+          <div className={styles.meta}>Filter by value, tag, owner, or environment</div>
+        </div>
+
+        <form className={styles.row} method="GET">
+          <input className={styles.input} name="q" placeholder="Search..." defaultValue={q} />
+          {view ? <input type="hidden" name="view" value={view} /> : null}
+          <button className={styles.buttonSecondary} type="submit">
+            Apply
+          </button>
+        </form>
+      </section>
+
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div className={styles.sectionTitle}>Inventory</div>
+          <div className={styles.meta}>Imported from `masat assets import`</div>
+        </div>
+
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th style={{ width: 90 }}>Kind</th>
+                <th>Asset</th>
+                <th style={{ width: 140 }}>Environment</th>
+                <th style={{ width: 160 }}>Owner</th>
+                <th>Tags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((a) => (
+                <tr key={`${a.kind}:${a.value}`}>
+                  <td className={styles.meta}>{a.kind}</td>
+                  <td>
+                    <strong>{a.value}</strong>
+                  </td>
+                  <td className={styles.meta}>{a.environment || ""}</td>
+                  <td className={styles.meta}>{a.owner || ""}</td>
+                  <td className={styles.meta}>{(a.tags || []).join(", ")}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className={styles.meta}>
+                    No assets found. Import some with: <code>masat assets import assets.csv</code>
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </AppShell>
+  );
+}

--- a/ui/src/lib/masatApi.ts
+++ b/ui/src/lib/masatApi.ts
@@ -1,6 +1,15 @@
 export type Scan = { id: string; description?: string };
 export type RunRow = { id: number; ts: number; target: string; scans: string[] };
 
+export type AssetRow = {
+  kind: string;
+  value: string;
+  tags: string[];
+  owner: string;
+  environment: string;
+  ts: number;
+};
+
 export type RunDetail = RunRow & {
   // API shape from GET /runs/{id}
   results: unknown;
@@ -40,6 +49,13 @@ export async function fetchRuns(limit = 20): Promise<RunRow[]> {
   if (!res.ok) throw new Error(`MASAT /runs failed: ${res.status}`);
   const data = await res.json();
   return data.runs || [];
+}
+
+export async function fetchAssets(limit = 200): Promise<AssetRow[]> {
+  const res = await fetch(`${baseUrl()}/assets?limit=${limit}`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`MASAT /assets failed: ${res.status}`);
+  const data = await res.json();
+  return data.assets || [];
 }
 
 export async function fetchRun(id: number): Promise<RunDetail> {


### PR DESCRIPTION
Adds an EASM-style Assets page to the UI.

### What
- API: `GET /assets` (lists assets from ~/.masat/assets.db)
- UI: `/assets` inventory table with search and lightweight saved view presets (All/Prod/Internet-facing)
- Navigation: adds Assets to sidebar

### Validation
- `pytest -q`
- `python3 -m py_compile api/app.py`
- `ui/`: `npm run lint` + `npm run build`